### PR TITLE
fix missing step

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 * `chmod +x macsu.sh && ln -s macsu.sh /usr/local/bin/macsu.sh`
 * `cp local.lcars.macOSSecurityUpdates.plist $HOME/Library/LaunchAgents/local.lcars.macOSSecurityUpdates.plist`
 * `launchctl load $HOME/Library/LaunchAgents/local.lcars.macOSSecurityUpdates.plist`
+* `./macsu.sh`
 * optional: install **[terminal-notifier](https://github.com/julienXX/terminal-notifier)**
 
 ### Testing


### PR DESCRIPTION
When following every step, `plutil -replace Version -integer 2098 "$HOME/.cache/macSU/XProtect.meta.plist" && launchctl start local.lcars.macOSSecurityUpdates`  will fail because `~/.cache/macSU/` doesn't exist until you execute `./macsu.sh`.

Command that produced error:

```
plutil -replace Version -integer 2098 "$HOME/.cache/macSU/XProtect.meta.plist" && launchctl start local.lcars.macOSSecurityUpdates
```

Error: 

```
/Users/example/.cache/macSU/XProtect.meta.plist: file does not exist or is not readable or is not a regular file (Error Domain=NSCocoaErrorDomain Code=260 "The file “XProtect.meta.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/example/.cache/macSU/XProtect.meta.plist, NSUnderlyingError=0x7fb300e05c20 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}})
```

### Solution:

execute `./macsu.sh` _before_ `plutil -replace Version -integer 2098 "$HOME/.cache/macSU/XProtect.meta.plist" && launchctl start local.lcars.macOSSecurityUpdates`